### PR TITLE
Fix STM32MP157C-EV1 image generation

### DIFF
--- a/br-ext/board/stmicroelectronics/stm32mp1-tz/genimage-STM32MP157C-EV1.cfg
+++ b/br-ext/board/stmicroelectronics/stm32mp1-tz/genimage-STM32MP157C-EV1.cfg
@@ -34,7 +34,7 @@ image sdcard.img {
 	}
 
 	partition bootfs {
-		image = "rootfs.ext2"
+		image = "bootfs.ext2"
 		partition-type-uuid = L
 		size = 32M
 		bootable = "yes"


### PR DESCRIPTION
stm32mp1: Fix 157C-EV1 bootfs partition image name parameter

Genimage script configuration had wrong image name on bootfs partition. changed the parameter "image" to correct name for the image to be generated successfully and to allow successful boot on STM32MP157C-EV1 board.

Signed-off-by: Timothée Cercueil <litchi.pi@protonmail.com>
Signed-off-by: Timothée Cercueil <timothee.cercueil@st.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
